### PR TITLE
Add QR code and left align sign in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "emailjs-com": "^3.2.0",
         "file-saver": "^2.0.5",
         "firebase": "^11.2.0",
+        "qrcode.react": "^4.2.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-easy-crop": "^5.5.7",
@@ -15096,6 +15097,15 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -28865,6 +28875,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+    },
+    "qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "requires": {}
     },
     "qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "emailjs-com": "^3.2.0",
     "file-saver": "^2.0.5",
     "firebase": "^11.2.0",
+    "qrcode.react": "^4.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-easy-crop": "^5.5.7",

--- a/src/components/EventSignin/EventSignin.css
+++ b/src/components/EventSignin/EventSignin.css
@@ -1,0 +1,19 @@
+.event-signin-form,
+.event-signin-form *,
+.event-signin-form h1,
+.event-signin-form h2,
+.event-signin-form h3,
+.event-signin-form h4,
+.event-signin-form .form-group,
+.event-signin-form .form-check,
+.event-signin-form .form-label,
+.event-signin-form .form-check-label,
+.event-signin-form label,
+.event-signin-form div,
+.event-signin-form p {
+  text-align: left;
+}
+
+.event-signin-form .form-check-label {
+  display: inline-block;
+}

--- a/src/components/EventSignin/EventSignin.js
+++ b/src/components/EventSignin/EventSignin.js
@@ -3,6 +3,7 @@ import { doc, getDoc, updateDoc, arrayUnion, increment } from "firebase/firestor
 import { auth, db } from "../firebase";
 import { useParams, useNavigate } from "react-router-dom";
 import Popup from "../Popup/Popup";
+import "./EventSignin.css";
 
 const EventSignin = () => {
   const { eventID } = useParams();
@@ -144,7 +145,7 @@ const EventSignin = () => {
               Attendance recorded successfully! Redirecting...
             </div>
           ) : (
-            <form onSubmit={handleSubmit}>
+            <form onSubmit={handleSubmit} className="event-signin-form">
                             {/* Attendance Code Section */}
               <div className="form-group">
                 <label>Enter Attendance Code:</label>

--- a/src/components/ManageEvents/ManageEvents.css
+++ b/src/components/ManageEvents/ManageEvents.css
@@ -316,10 +316,16 @@ body.manage-events-page::before {
   box-shadow: 0 4px 0 0 #e13a3a;
 }
 
+.manage-events-container .btn-qr {
+  background: #b48fef;
+  box-shadow: 0 4px 0 0 #895fd8;
+}
+
 .manage-events-container .btn-edit,
 .manage-events-container .btn-export,
 .manage-events-container .btn-copy,
-.manage-events-container .btn-delete {
+.manage-events-container .btn-delete,
+.manage-events-container .btn-qr {
   display: flex;
   padding: 0.0625rem 0.375rem;
   justify-content: center;
@@ -371,13 +377,110 @@ body.manage-events-page::before {
   transform: translateY(-1px);
 }
 
+.manage-events-container .btn-qr:hover:not(:disabled) {
+  background: #895fd8;
+  box-shadow: 0 4px 0 0 #7a4fc7;
+  transform: translateY(-1px);
+}
+
 .manage-events-container .btn-export:disabled,
 .manage-events-container .btn-copy:disabled,
 .manage-events-container .btn-delete:disabled,
-.manage-events-container .btn-edit:disabled {
+.manage-events-container .btn-edit:disabled,
+.manage-events-container .btn-qr:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   transform: none;
+}
+
+.qr-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.qr-modal {
+  position: relative;
+  background: #fff;
+  border-radius: 1rem;
+  padding: 2rem 2.5rem;
+  max-width: 90vw;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.qr-modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  color: #555;
+  cursor: pointer;
+}
+
+.qr-modal-title {
+  font-family: Gabarito;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #3a3536;
+  margin: 0;
+  text-align: center;
+}
+
+.qr-modal-subtitle {
+  font-family: Manrope;
+  font-size: 0.9rem;
+  color: #666;
+  margin: 0;
+}
+
+.qr-modal-canvas {
+  padding: 0.5rem;
+  background: #fff;
+  border-radius: 0.5rem;
+}
+
+.qr-modal-url {
+  font-family: Manrope;
+  font-size: 0.8rem;
+  color: #895fd8;
+  word-break: break-all;
+  text-align: center;
+  max-width: 320px;
+  margin: 0;
+}
+
+.qr-modal-download {
+  background: #b48fef;
+  box-shadow: 0 4px 0 0 #895fd8;
+  color: #fff;
+  border: none;
+  border-radius: 0.625rem;
+  padding: 0.5rem 1.25rem;
+  font-family: Gabarito;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.qr-modal-download:hover {
+  background: #895fd8;
+  box-shadow: 0 4px 0 0 #7a4fc7;
+  transform: translateY(-1px);
 }
 
 .icon {
@@ -585,7 +688,8 @@ body.manage-events-page::before {
   .manage-events-container .btn-export,
   .manage-events-container .btn-copy,
   .manage-events-container .btn-delete,
-  .manage-events-container .btn-edit {
+  .manage-events-container .btn-edit,
+  .manage-events-container .btn-qr {
     width: 100%;
     text-align: center;
     padding: 0.6rem;

--- a/src/components/ManageEvents/ManageEvents.js
+++ b/src/components/ManageEvents/ManageEvents.js
@@ -11,6 +11,7 @@ import {
 import { saveAs } from "file-saver";
 import { useNavigate } from "react-router-dom";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { QRCodeCanvas } from "qrcode.react";
 import Popup from "../Popup/Popup";
 import "./ManageEvents.css";
 
@@ -35,6 +36,19 @@ const ManageEvents = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const eventsPerPage = 12;
   const eventsContainerRef = useRef(null);
+  const [qrEvent, setQrEvent] = useState(null);
+  const qrCanvasRef = useRef(null);
+
+  const buildEventSigninUrl = (eventId) =>
+    `${window.location.origin}/eventsignin/${eventId}`;
+
+  const downloadQrCode = (event) => {
+    const canvas = qrCanvasRef.current?.querySelector("canvas");
+    if (!canvas) return;
+    canvas.toBlob((blob) => {
+      if (blob) saveAs(blob, `${event.name}-QR.png`);
+    });
+  };
 
   const handlePopupClose = useCallback(() => {
     setPopup({
@@ -622,6 +636,25 @@ const ManageEvents = () => {
                       </svg>
                       Export CSV
                     </button>
+                    <button
+                      className="btn-qr"
+                      onClick={() => setQrEvent(event)}
+                      title="Show QR Code"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                      >
+                        <path
+                          d="M0 0h7v7H0V0zm1.5 1.5v4h4v-4h-4zM9 0h7v7H9V0zm1.5 1.5v4h4v-4h-4zM0 9h7v7H0V9zm1.5 1.5v4h4v-4h-4zM9 9h2v2H9V9zm3 0h2v2h-2V9zm-3 3h2v2H9v-2zm3 3h2v1h-2v-1zm2-3h2v2h-2v-2zm0 3h2v1h-2v-1z"
+                          fill="white"
+                        />
+                      </svg>
+                      Show QR
+                    </button>
                   </div>
                   <div className="actions-bottom">
                     <button
@@ -812,6 +845,38 @@ const ManageEvents = () => {
         onConfirm={popup.onConfirm}
         onClose={handlePopupClose}
       />
+
+      {qrEvent && (
+        <div className="qr-modal-overlay" onClick={() => setQrEvent(null)}>
+          <div className="qr-modal" onClick={(e) => e.stopPropagation()}>
+            <button
+              className="qr-modal-close"
+              onClick={() => setQrEvent(null)}
+            >
+              ×
+            </button>
+            <h3 className="qr-modal-title">{qrEvent.name}</h3>
+            <p className="qr-modal-subtitle">
+              Scan to sign in to this event
+            </p>
+            <div className="qr-modal-canvas" ref={qrCanvasRef}>
+              <QRCodeCanvas
+                value={buildEventSigninUrl(qrEvent.id)}
+                size={256}
+                level="M"
+                includeMargin
+              />
+            </div>
+            <p className="qr-modal-url">{buildEventSigninUrl(qrEvent.id)}</p>
+            <button
+              className="qr-modal-download"
+              onClick={() => downloadQrCode(qrEvent)}
+            >
+              Download PNG
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/UpcomingEvents/SignInQuestions.css
+++ b/src/components/UpcomingEvents/SignInQuestions.css
@@ -1,3 +1,29 @@
+.sign-in-questions,
+.sign-in-questions * {
+  text-align: left;
+}
+
+.sign-in-questions .question {
+  margin-bottom: 1rem;
+}
+
+.sign-in-questions .question > label {
+  display: block;
+}
+
+.sign-in-questions .question > div > div {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.sign-in-questions .question > div > div > label {
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: 400;
+}
+
 .sign-in-questions-dropdown,
 .sign-in-questions-text {
   width: 100%;
@@ -17,15 +43,23 @@
 
 .sign-in-questions-mcq {
   display: flex;
-  gap: 1rem;
-  align-items: baseline;
+  gap: 0.5rem;
+  align-items: center;
   justify-content: flex-start;
 }
 
 .sign-in-question-tf {
   display: flex;
   gap: 1rem;
-  justify-content: center;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.sign-in-question-tf > label {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 0;
+  font-weight: 400;
 }
 
 .sign-in-question-checkbox {


### PR DESCRIPTION
## Title

feature: add per-event QR codes and left-align sign-in form questions

## PR Summary

Issue: #<issue-number>

Category: [ ] Fix  [x] Feature  [ ] Other

Description:
- Added a "Show QR" button to each event row in Manage Events (admin-only). Clicking it opens QR code encoding `${window.location.origin}/eventsignin/<eventID>`, the URL in text, and a "Download PNG" button. Participants can scan to land directly on the event sign-in page. Implemented with `qrcode.react`; no Firestore changes
- Fixed left-alignment of custom questions on the sign-in popup (`SignInQuestions`). 
- Applied the same alignment fix to the standalone `/eventsignin/:id` page so both sign-in flows stay consistent.

## Pre-PR Checks (Required)

- Run `npm run lint` — 0 errors
- Run `npm run build` — compiled successfully

## Final Checks

- [x] PR is linked to the correct issue
- [x] No merge conflicts with `main`
